### PR TITLE
Community: This mount was was not necessary in the `default_volumes`.

### DIFF
--- a/roles/deluge/tasks/main.yml
+++ b/roles/deluge/tasks/main.yml
@@ -30,7 +30,6 @@
       - "/etc/localtime:/etc/localtime:ro"
       - "/opt/deluge:/config"
       - "/opt/scripts:/scripts"
-      - "{{downloads.torrents}}:/downloads/torrents"
       - "/mnt:/mnt"
 
 - name: Create and start container

--- a/roles/qbittorrent/tasks/main.yml
+++ b/roles/qbittorrent/tasks/main.yml
@@ -31,7 +31,6 @@
       - "/etc/localtime:/etc/localtime:ro"
       - "/opt/qbittorrent:/config"
       - "/opt/scripts:/scripts"
-      - "{{downloads.torrents}}:/downloads/torrents"
       - "/mnt:/mnt"
 
 - name: Create and start container


### PR DESCRIPTION
- It was already included  in `torrents_downloads_path` from CB's 
pretasks/variables and mounted during `volumes: "{{ default_volumes + 
torrents_downloads_path|default([]) }}"`.